### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -7,6 +7,9 @@ on:
   repository_dispatch:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   prod:
     name: "prod"


### PR DESCRIPTION
Potential fix for [https://github.com/TUM-Blockchain-Club/blocksprint-website/security/code-scanning/1](https://github.com/TUM-Blockchain-Club/blocksprint-website/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the root of the workflow. This block will define the minimal permissions required for the workflow to function. Based on the provided context, the workflow likely needs `contents: read` to access repository contents and possibly no other permissions. If additional permissions are required, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
