### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - development
 
+permissions:
+  contents: read
+
 jobs:
   dev:
     name: "dev"


### PR DESCRIPTION
Potential fix for [https://github.com/TUM-Blockchain-Club/blocksprint-website/security/code-scanning/2](https://github.com/TUM-Blockchain-Club/blocksprint-website/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, it appears to deploy a development environment using secrets. Therefore, the `contents: read` permission is likely sufficient, as it allows the workflow to read repository contents. If additional permissions are required (e.g., `pull-requests: write`), they can be added explicitly.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`dev`) to limit permissions for that job only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
