### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: "Deploy Vercel"
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/TUM-Blockchain-Club/blocksprint-website/security/code-scanning/3](https://github.com/TUM-Blockchain-Club/blocksprint-website/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow primarily interacts with external services (Vercel) and does not modify repository contents, we will set `contents: read` as the minimal permission. This ensures the workflow can read repository contents if needed but cannot write to the repository or perform other actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
